### PR TITLE
Don't explicitly encode healthchecks.

### DIFF
--- a/docker/docker-compose.api.yml
+++ b/docker/docker-compose.api.yml
@@ -7,11 +7,6 @@ services:
       - 6479:6379
     extra_hosts:
       - "host.docker.internal:host-gateway"
-    healthcheck:
-      test: ["CMD", "redis-cli", "--raw", "incr", "ping"]
-      interval: 5s
-      timeout: 30s
-      retries: 10
   braintrust-postgres:
     image: public.ecr.aws/braintrust/postgres:latest
     command: postgres -c config_file=/etc/postgresql.conf
@@ -25,11 +20,6 @@ services:
       - "host.docker.internal:host-gateway"
     volumes:
       - api_pg_volume:/var/lib/postgresql/data
-    healthcheck:
-      test: ["CMD", "pg_isready"]
-      interval: 5s
-      timeout: 30s
-      retries: 10
   braintrust-standalone-api:
     image: public.ecr.aws/braintrust/standalone-api:latest
     env_file:

--- a/docker/docker-compose.full.yml
+++ b/docker/docker-compose.full.yml
@@ -9,11 +9,6 @@ services:
       - 6479:6379
     extra_hosts:
       - "host.docker.internal:host-gateway"
-    healthcheck:
-      test: ["CMD", "redis-cli", "--raw", "incr", "ping"]
-      interval: 5s
-      timeout: 30s
-      retries: 10
   braintrust-postgres:
     image: public.ecr.aws/braintrust/postgres:latest
     command: postgres -c config_file=/etc/postgresql.conf
@@ -27,11 +22,6 @@ services:
       - "host.docker.internal:host-gateway"
     volumes:
       - api_pg_volume:/var/lib/postgresql/data
-    healthcheck:
-      test: ["CMD", "pg_isready"]
-      interval: 5s
-      timeout: 30s
-      retries: 10
   braintrust-standalone-api:
     image: public.ecr.aws/braintrust/standalone-api:latest
     env_file:


### PR DESCRIPTION
The latest docker containers for postgres and redis encode the healthcheck in the image itself, so we don't need to repeat it in the docker compose files.

Note that this only works if you are using the latest docker images. But at worst you'll just have to either re-pull the images using `docker compose pull`, or, with the old images, restart the API service after starting up postgres/redis.