### PR TITLE
Add redis and pg connection params to `.env`

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -11,6 +11,7 @@
 # for the 'braintrust-redis' docker service.
 REDIS_HOST=host.docker.internal
 REDIS_PORT=6479
+REDIS_PASSWORD=''
 
 # Connection URI for the postgres instance. The general form of the URI is
 # `postgresql://[user[:password]@][host][:port][/dbname][?param1=value1&param2=value2...]`.

--- a/docker/.env
+++ b/docker/.env
@@ -5,6 +5,22 @@
 # After changing any environment variables, make sure to restart the docker
 # services for the changes to take effect.
 
+# These variables are used by both deployments.
+
+# Hostname and port of the redis instance. Defaults to the connection parameters
+# for the 'braintrust-redis' docker service.
+REDIS_HOST=host.docker.internal
+REDIS_PORT=6479
+
+# Connection URI for the postgres instance. The general form of the URI is
+# `postgresql://[user[:password]@][host][:port][/dbname][?param1=value1&param2=value2...]`.
+# Defaults to the URI for the 'braintrust-postgres' docker service.
+#
+# See
+# https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS
+# for full details on the URI spec.
+PG_URL=postgres://postgres:postgres@host.docker.internal:5532/postgres 
+
 # These variables are only used by the 'api' standalone deployment. They are
 # not used by the 'full' standalone deployment.
 


### PR DESCRIPTION
So that people can configure the API to connect to a different instance.