### PR TITLE
Specify a URL to connect to redis.

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -7,11 +7,10 @@
 
 # These variables are used by both deployments.
 
-# Hostname and port of the redis instance. Defaults to the connection parameters
-# for the 'braintrust-redis' docker service.
-REDIS_HOST=host.docker.internal
-REDIS_PORT=6479
-REDIS_PASSWORD=''
+# Connection URI for the redis instance. The general form of the URI is
+# `redis://[user[:password]@][host][:port][/db-number][?param1=value1&param2=value2...]`.
+# Defaults to the URI for the `braintrust-redis` docker service.
+REDIS_URL=redis://host.docker.internal:6479/0
 
 # Connection URI for the postgres instance. The general form of the URI is
 # `postgresql://[user[:password]@][host][:port][/dbname][?param1=value1&param2=value2...]`.


### PR DESCRIPTION
This lets us specify an arbitrary set of parameters, which can be useful for, say, connecting over SSL.