### PR TITLE
Cleanup .env and update full container to use split up aux components.

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -24,7 +24,9 @@ PG_URL=postgres://postgres:postgres@host.docker.internal:5532/postgres
 # These variables are only used by the 'api' standalone deployment. They are
 # not used by the 'full' standalone deployment.
 
-# Port on which to run the API server.
+# Port on which to run the API server. If you change this, you may want to set
+# the port mapping in the docker-compose.api file for braintrust-standalone-api
+# to '8000:[API_PORT]'.
 API_PORT=8000
 
 # These variables are only used by the 'full' standalone deployment. They are
@@ -34,14 +36,16 @@ API_PORT=8000
 #
 # Note: In a full url [scheme]://[domain]:[port]/[extra], this should just
 # include the [domain] part.
-PUBLIC_BASE_DOMAIN=localhost
+APP_PUBLIC_BASE_DOMAIN=localhost
 
-# CONTAINER_SERVER_SECRET only matters in "full configuration". In full config, the braintrust-standalone-aux
-# container allows you to issue api keys to new users (as a way to bootstrap access). You can lock down that
-# webserver so that only admins can access it. For example, you do not need to expose that container's port
-# externally. CONTAINER_SERVER_SECRET is a password that you can use as an additional layer of protection for 
-# that web server.
+# APP_BOOTSTRAP_CONTAINER_SERVER_SECRET only matters in "full configuration". In
+# full config, the braintrust-standalone-app-bootstrap container allows you to
+# issue api keys to new users (as a way to bootstrap access). You can lock down
+# that webserver so that only admins can access it. For example, you do not need
+# to expose that container's port externally.
+# APP_BOOTSTRAP_CONTAINER_SERVER_SECRET is a password that you can use as an
+# additional layer of protection for that web server.
 # 
-# CONTAINER_SERVER_SECRET's value must be included in the HTTP request as a header
-# 'Authorization: Bearer [secret]'.
-CONTAINER_SERVER_SECRET=my-secure-secret-token
+# APP_BOOTSTRAP_CONTAINER_SERVER_SECRET's value must be included in the HTTP
+# request as a header 'Authorization: Bearer [secret]'.
+APP_BOOTSTRAP_CONTAINER_SERVER_SECRET=my-secure-secret-token

--- a/docker/docker-compose.full.yml
+++ b/docker/docker-compose.full.yml
@@ -26,6 +26,8 @@ services:
     image: public.ecr.aws/braintrust/standalone-api:latest
     env_file:
       - .env
+    environment:
+      DEFAULT_HOSTNAME: host.docker.internal
     ports:
       - 8000:8000
     extra_hosts:
@@ -36,22 +38,34 @@ services:
       braintrust-postgres:
         condition: service_healthy
 
-  braintrust-standalone-aux:
-    image: public.ecr.aws/braintrust/standalone-aux:latest
-    env_file:
-      - .env
-    ports:
-      - 8001:8001
-      - 8100:8100
-      - 8788:8788
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
   braintrust-standalone-app:
     image: public.ecr.aws/braintrust/standalone-app:latest
     env_file:
       - .env
     ports:
       - 3000:3000
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+  braintrust-standalone-app-bootstrap:
+    image: public.ecr.aws/braintrust/standalone-app-bootstrap:latest
+    env_file:
+      - .env
+    ports:
+      - 8100:8100
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+  braintrust-standalone-proxy:
+    image: public.ecr.aws/braintrust/standalone-proxy:latest
+    environment:
+      BRAINTRUST_APP_URL: http://host.docker.internal:3000
+    ports:
+      - 8787:8787
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+  braintrust-standalone-realtime:
+    image: public.ecr.aws/braintrust/standalone-realtime:latest
+    ports:
+      - 8788:8788
     extra_hosts:
       - "host.docker.internal:host-gateway"
 


### PR DESCRIPTION
The changes should only affect people using the 'full' deployment, which should be a small set of folks. And nothing data-wise is different, mainly just the containers and the names of some env variables.

Will merge this after deploying the new containers.