### PR TITLE
Align with internal change to default response bucket to empty.

### DIFF
--- a/docker/docker-compose.api.yml
+++ b/docker/docker-compose.api.yml
@@ -100,8 +100,6 @@ services:
       CLICKHOUSE_PG_URL: ""
       CLICKHOUSE_CONNECT_URL: ""
       REDIS_URL: redis://host.docker.internal:6479/0
-      # Internal setting. Leave this as-is.
-      RESPONSE_BUCKET: ""
       # If you are deploying any other services yourself, such as the proxy or
       # realtime, you may override their URLs here as well (PROXY_URL and
       # REALTIME_URL, respectively). See the environment settings in

--- a/docker/docker-compose.full.yml
+++ b/docker/docker-compose.full.yml
@@ -154,8 +154,6 @@ services:
       CLICKHOUSE_PG_URL: ""
       CLICKHOUSE_CONNECT_URL: ""
       REDIS_URL: redis://host.docker.internal:6479/0
-      # Internal setting. Leave this as-is.
-      RESPONSE_BUCKET: ""
     ports:
       - 8000:8000
     extra_hosts:


### PR DESCRIPTION
This way we don't break backwards compatibility with people's existing docker compose files.